### PR TITLE
Testrail initializer

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,7 +20,7 @@ defaults: &defaults
     client_pem:
   testmite:
     url: http://testmite.url
-#  test_rail:
+  test_rail:
     #testrail_account_one:
     #  user:
     #  password:


### PR DESCRIPTION
Rename the test_rail.rb initializer so that it is loaded before the builder.rb initializer.

Example:

Load with TestRail config:

``` ruby
TEST_RAIL_ACCOUNT_PASSWORD='blah' TEST_RAIL_ACCOUNT_USER='blah2' bundle exec rails c
2.2.3 :001 > Builders::Registry.registered_builders
 => [Builders::TestRail, Builders::ManualBuilder] 
```

Load without TestRail config:

``` ruby
bundle exec rails c
2.2.3 :001 > Builders::Registry.registered_builders
 => [Builders::ManualBuilder] 
```
