### PR TITLE
Pin the mysql2 gem to ~> 0.3.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'aws-sdk', '~> 1.6'
 
 gem 'chamber'
 
-gem 'chartjs-ror'
+gem 'chartjs-ror', '> 3'
 gem 'd3-rails'
 
 gem 'omniauth'

--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,5 @@ group :test do
 end
 
 group :production do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'aws-sdk', '~> 1.6'
 
 gem 'chamber'
 
-gem 'chartjs-ror', '> 3'
+gem 'chartjs-ror', '>= 3'
 gem 'd3-rails'
 
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ DEPENDENCIES
   bootstrap-switch-rails (< 3.1.0)
   cachethod (~> 0.2.0)
   chamber
-  chartjs-ror
+  chartjs-ror (>= 3)
   cocoon
   codeclimate-test-reporter
   d3-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     minitest (5.9.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    mysql2 (0.4.5)
+    mysql2 (0.3.21)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     omniauth (1.3.1)
@@ -303,7 +303,7 @@ DEPENDENCIES
   jquery-rails
   js-routes
   mind_meld (~> 0.1)
-  mysql2
+  mysql2 (~> 0.3.18)
   omniauth
   paperclip
   paranoia (~> 2.0.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
-//= require Chart
+//= require Chart.min
 //= require cocoon
 //= require js-routes
 //= require jquery.serialize-hash


### PR DESCRIPTION
This is a problem with Rails 4.1 and 4.2 which do not start with mysql2 0.4.
This is fixed in later versions of 4.2 but Hive Scheduler currently uses 4.1.